### PR TITLE
Add unWISE (IRSA-6198)

### DIFF
--- a/datasets/wise-unwise.yaml
+++ b/datasets/wise-unwise.yaml
@@ -1,5 +1,5 @@
 Name: "Unblurred Coadds of the Wide-field Infrared Survey Explorer (unWISE)"
-Description: "unWISE is a reprocessing of Wide-field Infrared Survey Explorer (WISE) data which preserves the native angular resolution and is optimized for forced photometry. WISE was a NASA satellite producing all-sky imaging in four infrared bands centered at 3.4, 4.6, 12 and 22 microns (W1, W2, W3, and W4) starting in 2010 until the coolant was exhausted in 2011. It was reactivated in 2013 as NEOWISE and continued imaging in W1 and W2 until 2024. "
+Description: "unWISE is a reprocessing of Wide-field Infrared Survey Explorer (WISE) data which preserves the native angular resolution and is optimized for forced photometry. WISE was a NASA satellite producing all-sky imaging in four infrared bands centered at 3.4, 4.6, 12 and 22 microns (W1, W2, W3, and W4) starting in 2010 until the coolant was exhausted in 2011. It was reactivated in 2013 as NEOWISE and continued imaging in W1 and W2 until 2024."
 Documentation: https://irsa.ipac.caltech.edu/data/WISE/unWISE/overview.html
 Contact: https://irsa.ipac.caltech.edu/docs/help_desk.html
 ManagedBy: "NASA/IPAC Infrared Science Archive ([IRSA](https://irsa.ipac.caltech.edu)) at Caltech"
@@ -13,8 +13,7 @@ Tags:
   - satellite imagery
   - survey
 License: https://irsa.ipac.caltech.edu/data_use_terms.html
-Citation: "If you use the unWISE Time-Domain Catalog, please cite the dataset Digital Object Identifier (DOI):
-[10.26131/IRSA580](https://www.ipac.caltech.edu/doi/irsa/10.26131/IRSA580). In addition, follow the [unWISE acknowledgement guidelines](https://irsa.ipac.caltech.edu/data/WISE/unWISE/overview.html) and the [IRSA acknowledgement guidelines](https://irsa.ipac.caltech.edu/ack.html)."
+Citation: "If you use the unWISE Time-Domain Catalog, please cite the dataset Digital Object Identifier (DOI): [10.26131/IRSA580](https://www.ipac.caltech.edu/doi/irsa/10.26131/IRSA580). In addition, follow the [unWISE acknowledgement guidelines](https://irsa.ipac.caltech.edu/data/WISE/unWISE/overview.html) and the [IRSA acknowledgement guidelines](https://irsa.ipac.caltech.edu/ack.html)."
 Resources:
   - Description: "The unWISE Time-Domain Catalog is based on 'time-resolved' coadds, each of which stacks together the WISE/NEOWISE exposures from one (biannual) sky pass. It includes 43 billion total detections in W1 and W2. It is available in Apache Parquet, partitioned by HEALPix order 5."
     ARN: arn:aws:s3:::nasa-irsa-wise/unwise/

--- a/datasets/wise-unwise.yaml
+++ b/datasets/wise-unwise.yaml
@@ -1,0 +1,32 @@
+Name: "Unofficial, Unblurred Coadds of the Wide-field Infrared Survey Explorer (unWISE)"
+Description: "unWISE is a reprocessing of Wide-field Infrared Survey Explorer (WISE) data to improved depth and spatial resolution. WISE is a NASA Medium Explorer satellite in low-Earth orbit conducting an all-sky astronomical imaging survey. It imaged in four infrared bands centered at 3.4, 4.6, 12 and 22 microns (W1, W2, W3, and W4) starting in 2010 until the coolant was exhausted. It was reactivated in 2013 as NEOWISE and continued imaging in W1 and W2. The unWISE Time-Domain Catalog is based on 'time-resolved' coadds, each of which stacks together the WISE/NEOWISE exposures from one (biannual) sky pass."
+Documentation: https://irsa.ipac.caltech.edu/data/WISE/unWISE/overview.html
+Contact: https://irsa.ipac.caltech.edu/docs/help_desk.html
+ManagedBy: "NASA/IPAC Infrared Science Archive ([IRSA](https://irsa.ipac.caltech.edu)) at Caltech"
+UpdateFrequency: The unWISE dataset is updated periodically to include new data released by NEOWISE. The data may also be presented in new ways as the products become available.
+Tags:
+  - aws-pds
+  - astronomy
+  - imaging
+  - object detection
+  - parquet
+  - satellite imagery
+  - survey
+License: https://irsa.ipac.caltech.edu/data_use_terms.html
+Citation: "If you use the unWISE Time-Domain Catalog, please cite the dataset Digital Object Identifier (DOI):
+[10.26131/IRSA580](https://www.ipac.caltech.edu/doi/irsa/10.26131/IRSA580). In addition, follow the [unWISE acknowledgement guidelines](https://irsa.ipac.caltech.edu/data/WISE/unWISE/overview.html) and the [IRSA acknowledgement guidelines](https://irsa.ipac.caltech.edu/ack.html)."
+Resources:
+  - Description: "The unWISE Time-Domain Catalog is based on 'time-resolved' coadds, each of which stacks together the WISE/NEOWISE exposures from one (biannual) sky pass. It includes 43 billion total detections in W1 and W2. It is available in Apache Parquet, partitioned by HEALPix order 5."
+    ARN: arn:aws:s3:::nasa-irsa-wise/unwise/
+    Region: us-west-2
+    Type: S3 Bucket
+    RequesterPays: False
+    AccountRequired: False
+DataAtWork:
+  Tutorials:
+    - Title: Notebook Tutorials
+      URL: https://irsa.ipac.caltech.edu/docs/notebooks/
+      AuthorName: Caltech/IPAC-IRSA
+      AuthorURL: https://irsa.ipac.caltech.edu
+ADXCategories:
+  - Public Sector Data

--- a/datasets/wise-unwise.yaml
+++ b/datasets/wise-unwise.yaml
@@ -1,5 +1,5 @@
-Name: "Unofficial, Unblurred Coadds of the Wide-field Infrared Survey Explorer (unWISE)"
-Description: "unWISE is a reprocessing of Wide-field Infrared Survey Explorer (WISE) data to improved depth and spatial resolution. WISE is a NASA Medium Explorer satellite in low-Earth orbit conducting an all-sky astronomical imaging survey. It imaged in four infrared bands centered at 3.4, 4.6, 12 and 22 microns (W1, W2, W3, and W4) starting in 2010 until the coolant was exhausted. It was reactivated in 2013 as NEOWISE and continued imaging in W1 and W2. The unWISE Time-Domain Catalog is based on 'time-resolved' coadds, each of which stacks together the WISE/NEOWISE exposures from one (biannual) sky pass."
+Name: "Unblurred Coadds of the Wide-field Infrared Survey Explorer (unWISE)"
+Description: "unWISE is a reprocessing of Wide-field Infrared Survey Explorer (WISE) data which preserves the native angular resolution and is optimized for forced photometry. WISE was a NASA satellite producing all-sky imaging in four infrared bands centered at 3.4, 4.6, 12 and 22 microns (W1, W2, W3, and W4) starting in 2010 until the coolant was exhausted in 2011. It was reactivated in 2013 as NEOWISE and continued imaging in W1 and W2 until 2024. "
 Documentation: https://irsa.ipac.caltech.edu/data/WISE/unWISE/overview.html
 Contact: https://irsa.ipac.caltech.edu/docs/help_desk.html
 ManagedBy: "NASA/IPAC Infrared Science Archive ([IRSA](https://irsa.ipac.caltech.edu)) at Caltech"


### PR DESCRIPTION
This PR contains a yaml file that will be used to generate the AWS ODR webpage for unWISE.
We intend the webpage to support any/all unWISE products, though initially only the Time-Domain catalog will be there. You can look at NEOWISE ([yaml](https://github.com/awslabs/open-data-registry/blob/main/datasets/wise-neowiser.yaml), [webpage](https://registry.opendata.aws/wise-neowiser/)) as an example to see what the webpages look like and which fields end up where.

Most important to review is the name and both descriptions. I made those up based on other WISE/NEOWISE and unWISE documentation. First description should be a "high-level description of the dataset", so it should cover all of unWISE, and should be 600 characters or less. (The final sentence about the Time-Domain catalog can be removed if we need the space.) Second description should be a "technical description of the data available within the AWS resource" -- for now that's just the Time-Domain catalog.

AWS's explanation of all fields in the yaml file is at https://github.com/awslabs/open-data-registry/blob/main/README.md.

There is a link in the yaml to the unWISE overview page (https://irsa.ipac.caltech.edu/data/WISE/unWISE/overview.html). That page will be updated to include the Time-Domain catalog as part of the catalog release ([IRSA-6215](https://jira.ipac.caltech.edu/browse/IRSA-6215)). You can view the draft updates at https://irsadev.ipac.caltech.edu/data/WISE/unWISE/overview.html.

The Time-Domain catalog paper is [Meisner, Caselden, Schlafly, & Kiwy (2023)](https://iopscience.iop.org/article/10.3847/1538-3881/aca2ab).